### PR TITLE
Send events in batches of 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,11 @@ Fluentd output plugin to send events to [Indicative](https://www.indicative.com/
   event_name_key        event_name
   event_time_key        created_at
   event_unique_id_keys  user_id, cookie_id, session_id  # keys to search for unique user ID value, in order of priority
+
+  # Optionally use buffering (recommended for high event volumes)
+  <buffer>
+    path /var/log/td-agent/indicative.buffer
+    chunk_limit_records 1000
+  </buffer>
 </match>
 ```

--- a/lib/fluent/plugin/out_indicative.rb
+++ b/lib/fluent/plugin/out_indicative.rb
@@ -5,6 +5,8 @@ require 'uri'
 
 require 'fluent/plugin/output'
 
+BATCH_SIZE = 100
+
 
 def flatten_hash(hash)
   hash.each_with_object({}) do |(k, v), h|
@@ -29,7 +31,7 @@ class Fluent::Plugin::IndicativeOutput < Fluent::Plugin::Output
   config_param :event_unique_id_keys, :array, value_type: :string
 
   def process(tag, es)
-    es.each_slice(100) do |events|
+    es.each_slice(BATCH_SIZE) do |events|
       send_events(events.map {|time, record| record})
     end
   end
@@ -39,7 +41,7 @@ class Fluent::Plugin::IndicativeOutput < Fluent::Plugin::Output
     chunk.each do |time, record|
       records << record
     end
-    records.each_slice(100) do |events|
+    records.each_slice(BATCH_SIZE) do |events|
       send_events(events)
     end
   end

--- a/test/plugin/test_out_indicative.rb
+++ b/test/plugin/test_out_indicative.rb
@@ -39,16 +39,18 @@ class IndicativeOutputTest < Test::Unit::TestCase
     assert_requested :post, d.instance.api_url,
       headers: {'Content-Type' => 'application/json'}, body: {
         'apiKey' => 'INDICATIVE_API_KEY',
-        'eventName' => 'screen_view',
-        'eventUniqueId' => 'a3bd2',
-        'properties' => {
-          'event_name' => 'screen_view',
-          'created_at' => '2015-01-01T10:00:00.000Z',
-          'session_id' => 'a3bd2',
-          'user_id' => nil,
-          'screen.id' => 'index'
-        },
-        'eventTime' => '2015-01-01T10:00:00+00:00'
+        'events' => [{
+          'eventName' => 'screen_view',
+          'eventUniqueId' => 'a3bd2',
+          'properties' => {
+            'event_name' => 'screen_view',
+            'created_at' => '2015-01-01T10:00:00.000Z',
+            'session_id' => 'a3bd2',
+            'user_id' => nil,
+            'screen.id' => 'index'
+          },
+          'eventTime' => '2015-01-01T10:00:00+00:00'
+        }]
       }.to_json, times: 1
   end
 end

--- a/test/plugin/test_out_indicative.rb
+++ b/test/plugin/test_out_indicative.rb
@@ -5,14 +5,29 @@ class IndicativeOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  CONFIG = %[
+  STREAM_CONFIG = %[
     api_key               INDICATIVE_API_KEY
     event_name_key        event_name
     event_time_key        created_at
     event_unique_id_keys  user_id, session_id
   ]
 
-  def create_driver(conf=CONFIG)
+  BUFFER_CONFIG = %[
+    api_key               INDICATIVE_API_KEY
+    event_name_key        event_name
+    event_time_key        created_at
+    event_unique_id_keys  user_id, session_id
+
+    <buffer>
+      chunk_limit_records 50
+    </buffer>
+
+    <format>
+      @type json
+    </format>
+  ]
+
+  def create_driver(conf=STREAM_CONFIG)
     Fluent::Test::Driver::Output.new(Fluent::Plugin::IndicativeOutput).configure(conf)
   end
 
@@ -20,7 +35,7 @@ class IndicativeOutputTest < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError) {
       d = create_driver('')
     }
-    d = create_driver CONFIG
+    d = create_driver(STREAM_CONFIG)
     assert_equal 'INDICATIVE_API_KEY', d.instance.api_key
     assert_equal 'event_name', d.instance.event_name_key
     assert_equal 'created_at', d.instance.event_time_key
@@ -28,8 +43,8 @@ class IndicativeOutputTest < Test::Unit::TestCase
   end
 
 
-  def test_emit
-    d = create_driver(CONFIG)
+  def test_emit_stream
+    d = create_driver(STREAM_CONFIG)
     stub_request(:any, d.instance.api_url)
     d.run(default_tag: 'test') do
       d.feed({'event_name' => 'screen_view', 'created_at' => '2015-01-01T10:00:00.000Z', 'session_id' => 'a3bd2', 'user_id' => nil, 'screen' => {'id' => 'index'}})
@@ -52,5 +67,18 @@ class IndicativeOutputTest < Test::Unit::TestCase
           'eventTime' => '2015-01-01T10:00:00+00:00'
         }]
       }.to_json, times: 1
+  end
+
+  def test_emit_buffer
+    d = create_driver(BUFFER_CONFIG)
+    stub_request(:any, d.instance.api_url)
+    d.run(default_tag: 'test') do
+      20.times do
+        d.feed({'event_name' => 'screen_view', 'created_at' => '2015-01-01T10:00:00.000Z', 'session_id' => 'a3bd2', 'user_id' => nil, 'screen' => {'id' => 'index'}})
+      end
+    end
+    events = d.events
+    assert_equal 0, events.length
+    assert_requested :post, d.instance.api_url, times: 1
   end
 end


### PR DESCRIPTION
Make use of the batch functionality in the Indicative API rather than streaming events one by one.